### PR TITLE
Update IConstants.java

### DIFF
--- a/src/org/geoconvertor/utm/IConstants.java
+++ b/src/org/geoconvertor/utm/IConstants.java
@@ -37,7 +37,7 @@ public interface IConstants {
 	 */
 	public static final double K0 = 0.999995; // Scale Factor
 
-	public static final char DEGREE = '°';
+	public static final char DEGREE = '\u00BA';
 	public static final char MINUTE = '\'';
 	public static final char SECOND = '"';
 	public static final char NORTH = 'N';


### PR DESCRIPTION
Change back to the original char - (char) 176 - but in unicode definition. So backward compatibility will be satisfied, but tools like **StringUtils** from **commons-lang** cold be used too with following request, for example: `StringUtils.substringBefore(String, "\u00BA");`